### PR TITLE
fix: IME composition events not propagated in AutoResizeTextarea

### DIFF
--- a/frontend/src/components/AutoResizeTextarea.tsx
+++ b/frontend/src/components/AutoResizeTextarea.tsx
@@ -8,6 +8,12 @@ interface Props extends Omit<React.ComponentProps<'textarea'>, 'onPaste'> {
   placeholder?: string;
   onPaste?: (event: ClipboardEvent) => void;
   onEnter?: (event: React.KeyboardEvent<HTMLTextAreaElement>) => void;
+  onCompositionStart?: (
+    event: React.CompositionEvent<HTMLTextAreaElement>
+  ) => void;
+  onCompositionEnd?: (
+    event: React.CompositionEvent<HTMLTextAreaElement>
+  ) => void;
 }
 
 const AutoResizeTextarea = ({
@@ -17,6 +23,8 @@ const AutoResizeTextarea = ({
   placeholder,
   className,
   onKeyDown,
+  onCompositionStart,
+  onCompositionEnd,
   ...props
 }: Props) => {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -60,13 +68,31 @@ const AutoResizeTextarea = ({
     }
   };
 
+  const handleCompositionStart = (
+    event: React.CompositionEvent<HTMLTextAreaElement>
+  ) => {
+    setIsComposing(true);
+    if (onCompositionStart) {
+      onCompositionStart(event);
+    }
+  };
+
+  const handleCompositionEnd = (
+    event: React.CompositionEvent<HTMLTextAreaElement>
+  ) => {
+    setIsComposing(false);
+    if (onCompositionEnd) {
+      onCompositionEnd(event);
+    }
+  };
+
   return (
     <Textarea
       ref={textareaRef as any}
       {...props}
       onKeyDown={handleKeyDown}
-      onCompositionStart={() => setIsComposing(true)}
-      onCompositionEnd={() => setIsComposing(false)}
+      onCompositionStart={handleCompositionStart}
+      onCompositionEnd={handleCompositionEnd}
       className={cn(
         'p-0 min-h-[40px] h-[40px] rounded-none resize-none border-none overflow-y-auto shadow-none focus:ring-0 focus:ring-offset-0 focus-visible:ring-0 focus-visible:ring-offset-0',
         className


### PR DESCRIPTION
## Summary

Fixes a bug where Japanese (and other IME-based) input would incorrectly send messages when pressing Enter during text conversion.

## Problem

After PR #2393 rewrote the chat input to use `<textarea>`, the `AutoResizeTextarea` component was not propagating `onCompositionStart` and `onCompositionEnd` events to its parent component (`Input.tsx`). This caused the parent's `isComposing` state to always remain `false`, resulting in Enter key presses during IME text conversion being incorrectly interpreted as message send commands.

## Solution

- Added `onCompositionStart` and `onCompositionEnd` to `AutoResizeTextarea` component props
- Created handler functions that:
  1. Update the component's internal `isComposing` state
  2. Propagate the events to parent handlers if provided
- This ensures both the `AutoResizeTextarea` and parent components correctly track IME composition state

## Test Plan

Tested with Japanese IME input:
1. ✅ Type "english" and press Enter → message sends correctly
2. ✅ Type "こんにちは" (Japanese) and press Enter during conversion → text is confirmed, message does NOT send
3. ✅ After confirming Japanese text, press Enter → message sends correctly

## Related Issues

This bug was introduced in PR #2393 when migrating from `contentEditable` to `<textarea>`.